### PR TITLE
Added stream methods including stream-element-type

### DIFF
--- a/gray-streams-pipe.lisp
+++ b/gray-streams-pipe.lisp
@@ -9,12 +9,18 @@
    (input :initarg :input :accessor input-of)
    (output :initarg :output :accessor output-of)))
 
-;; (defmethod stream-element-type ((stream pipe))
-;;   (stream-element-type (output-of stream)))
+(defmethod stream-element-type ((stream pipe))
+  (stream-element-type (output-of stream)))
 
 (defmethod trivial-gray-streams:stream-write-char ((p pipe) character)
   (bt:with-lock-held ((lock-of p))
     (write-char character (output-of p))))
+
+(defmethod trivial-gray-streams:stream-write-string
+    ((p pipe) string &optional start end)
+  (let* ((str (subseq string (if start start 0) end)))
+    (bt:with-lock-held ((lock-of p))
+      (map nil (lambda (c) (write-char c (output-of p))) str))))
 
 (defun flush-in-to-out (pipe)
   (let ((string (get-output-stream-string (output-of pipe))))

--- a/gray-streams-pipe.lisp
+++ b/gray-streams-pipe.lisp
@@ -26,7 +26,7 @@
     ((p pipe) string &optional start end)
   (let* ((str (subseq string (if start start 0) end)))
     (bt:with-lock-held ((lock-of p))
-      (map nil (lambda (c) (write-char c (output-of p))) str))))
+      (write-string str (output-of p)))))
 
 (defun flush-in-to-out (pipe)
   (let ((string (get-output-stream-string (output-of pipe))))

--- a/gray-streams-pipe.lisp
+++ b/gray-streams-pipe.lisp
@@ -8,15 +8,15 @@
   ((lock :initform (bordeaux-threads:make-lock) :accessor lock-of)
    (input :initarg :input :accessor input-of)
    (output :initarg :output :accessor output-of)
-   (element-type :initarg :element-type :accessor pipe-element-type)))
+   (element-type :initarg :element-type :accessor element-type)))
 
 (defmethod initialize-instance :after
     ((p pipe) &key)
-  (setf (pipe-element-type p)
+  (setf (element-type p)
         (stream-element-type (output-of p))))
 
 (defmethod stream-element-type ((stream pipe))
-  (pipe-element-type stream))
+  (element-type stream))
 
 (defmethod trivial-gray-streams:stream-write-char ((p pipe) character)
   (bt:with-lock-held ((lock-of p))


### PR DESCRIPTION
I found that the `stream-element-type` method was commented out and discovered upon using it that there needed to be another state variable and an `:after` method for `initialize-instance` to make this work properly in all use cases.

Additionally I added the missing stream-write-char method so that e.g. `format` and other functions would work properly with pipes.